### PR TITLE
Support touch event for mobile safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,12 @@ export default class OnClickOut extends Component {
 
 	componentDidMount() {
 		document.addEventListener("click", this.onClick);
+		document.addEventListener("touchstart", this.onClick);
 	}
 
 	componentWillUnmount() {
 		document.removeEventListener("click", this.onClick);
+		document.removeEventListener("touchstart", this.onClick);
 	}
 
 	render() {


### PR DESCRIPTION
On Safari mobile, click events just don't work like they used to. Utilize touch events to simulate whatever we may need.